### PR TITLE
emotelist server selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CinnaBot",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Cinnabar has entered the Gem-to-Lunarian transformation machine.",
   "main": "index.js",
   "author": "Kazumik",


### PR DESCRIPTION
emotelist.js command now lets the user select the server they wish to show the emotes for. They are only allowed to select from the servers they share with the bot, however.

Modified the display of the emotes to add clarity when showing emotes for multiple servers in a single channel.